### PR TITLE
Use opencv-python-headless for dependency instead of opencv-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "easypaddleocr"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
     { name = "pk5ls20" },
     { name = "hv0905" }
@@ -20,7 +20,7 @@ dependencies = [
     "imgaug",
     "pyclipper",
     "numpy",
-    "opencv-python",
+    "opencv-python-headless",
     "Pillow",
     "pyyaml",
     "torch",


### PR DESCRIPTION
It seems that opencv-python will break some headless environment such as docker:
![image](https://github.com/pk5ls20/EasyPaddleOCR/assets/29349119/97167e6b-6b7f-45b7-937f-1dc36b7660fa)

![image](https://github.com/pk5ls20/EasyPaddleOCR/assets/29349119/3837d8f2-3b51-4578-a434-03fe1feb4f11)

Related link: https://stackoverflow.com/a/69125651/10203923